### PR TITLE
Add drop reason example

### DIFF
--- a/drop_reason/Makefile
+++ b/drop_reason/Makefile
@@ -1,0 +1,36 @@
+## call with make PROG=xxx to build
+##  make PROG=xxx clean|generate|realclean
+#
+## Argument for the CLANG compiler
+CLANG ?= clang
+P4C_PNA_P4TC ?= p4c-pna-p4tc
+PROG ?= drop_reason
+#we need to have a headers package instead of this..
+INCLUDES= -I../include
+# Optimization flags to save space
+CFLAGS+= -O1 -g -c -D__KERNEL__ -D__ASM_SYSREG_H -DBTF \
+	 -Wno-unused-value  -Wno-pointer-sign \
+	 -Wno-compare-distinct-pointer-types \
+	 -Wno-gnu-variable-sized-type-not-at-end \
+	 -Wno-address-of-packed-member -Wno-tautological-compare \
+	 -Wno-unknown-warning-option -Wnoparentheses-equality
+
+TMPL+=generated/$(PROG).template
+TMPL+=generated/$(PROG).json
+SRCS+=generated/$(PROG)_parser.c
+SRCS+=generated/$(PROG)_control_blocks.c
+OBJS=$(SRCS:.c=.o)
+all: $(OBJS)
+
+$(OBJS): %.o : %.c
+	$(CLANG) $(CFLAGS) $(INCLUDES) --target=bpf -mcpu=probe -c $< -o $@
+
+# Disable uninitialized_use because compiler is emitting a false positive in the parser
+generate:
+	$(P4C_PNA_P4TC) $(PROG).p4 --Wdisable=uninitialized_use -o generated
+
+clean:
+	rm -f $(OBJS)
+
+realclean:
+	rm -f $(OBJS) $(SRCS) $(TMPL) $(PROG)_parser.h

--- a/drop_reason/README.md
+++ b/drop_reason/README.md
@@ -1,0 +1,326 @@
+# Drop Reason
+
+This program demonstrates how to capture events from the datapath and log them as events to the control plane.
+In this case we capture the reason why packets are dropped, what port they arrived on and what src mac address was observed on the packet.
+Packets could be dropped for two reasons:
+
+- The parser was unable to parse the packet
+- Unable to find a matching entry on lookup of table nh\_table.
+
+The *drop_reason* program first parses ethernet <u>ipv4</u> packets.
+Any other packets are rejected and will result in a drop_reason digest event being sent with the packet's `ingress_port`, src mac address and drop reason set to `parser_rejected`.
+After the parser recognizes an ipv4 packet, the src ip address is used as a lookup
+key for table *nh_table*. On a table hit, the programmed action *send_nh(port, srcMac, dstMac)* instance is executed.
+The action first sets the src and destination mac address, then redirects the packet to a specified port.
+On a table miss, the program sets the `ingress_port`, `send_digest` to true, drop reason to `table_miss` and marks the packet to be dropped.
+`my_ingress_metadata_t` will hold the port on where the packet arrived, the drop reason and `send_digest`.
+`send_digest` signals the deparser to send a digest message to user space.
+This digest message will hold the source mac address, the port where the packet arrived and the drop reason:
+
+```
+struct mac_learn_digest_t {
+    @tc_type("macaddr") bit<48> srcAddr;
+    @tc_type("dev") PortId_t ingress_port;
+    DROP_REASON drop_reason;
+};
+```
+
+## Setup Requirements
+
+Make sure that the p4node basic container has already been created at this point(as per instructions found in [p4node](https://github.com/p4tc-dev/p4tc-examples-pub.git)). To run the sample described setup here requires 5 terminals, four terminals inside the container and one on the VM side to generate traffic.
+
+### Terminal 1 (observation of tc commands on p4node).
+
+Enter the container p4node:
+
+`sudo ip netns exec p4node /bin/bash`
+
+setup path for TC binary
+
+`TC="/usr/sbin/tc"`
+
+setup the path to where the json introspection file can be found..
+
+```
+cd /home/vagrant/p4tc-examples-pub/drop_reason/generated
+export INTROSPECTION=.
+```
+run TC monitor:
+`$TC mon p4 events`
+
+### Terminal 2 (observation of p4 digest events on p4node).
+
+First enter the container and make sure you have the introspection path setup
+
+Enter the container p4node:
+
+`sudo ip netns exec p4node /bin/bash`
+
+setup path for TC binary
+
+`TC="/usr/sbin/tc"`
+
+setup the path to where the json introspection file can be found..
+
+```
+cd /home/vagrant/p4tc-examples-pub/drop_reason/generated
+export INTROSPECTION=.
+```
+
+run TC monitor for digest events:
+`$TC mon p4 digest`
+
+### Terminal 3 (observes incoming traffic into p4node)
+
+First enter the container and make sure you have the introspection path setup
+
+`sudo ip netns exec p4node /bin/bash`
+
+Now let's listen to traffic on port0
+
+```
+DEV=port0
+tcpdump -n -i $DEV -e
+```
+
+### Terminal 4 (to instantiate and runtime control the program)
+
+We will run commands to first load the prog and then do required runtime setup.
+
+First enter the container
+
+```
+sudo ip netns exec p4node /bin/bash
+cd /home/vagrant/p4tc-examples-pub/drop_reason
+```
+
+Compile the parser and control blocks programs if you have not already
+
+`make`
+
+Make sure you have the introspection path setup and load the *digest* program
+
+```
+cd generated
+export INTROSPECTION=.
+TC="/usr/sbin/tc"
+./drop_reason.template
+```
+
+now instantiate the prog
+
+```
+$TC filter add block 21 ingress protocol all prio 10 p4 pname drop_reason \
+action bpf obj drop_reason_parser.o section p4tc/parse \
+action bpf obj drop_reason_control_blocks.o section p4tc/main
+```
+
+### Terminal 5 (on the VM side)
+
+Try sending a message of packets which will be dropped by the parser ..
+
+`ping -I p4port0 10.0.1.2 -c 1`
+
+Let's check some stats, below shows 3 packets dropped by the parser on <u>terminal 3</u>:
+
+```
+$TC -s filter ls block 21 ingress
+filter protocol all pref 10 p4 chain 0
+filter protocol all pref 10 p4 chain 0 handle 0x1 pname drop_reason
+	action order 1: bpf drop_reason_parser.o:[p4tc/parse] id 92 name tc_parse_func tag 1bd66321c5ad54e4 jited default-action pipe
+	index 1 ref 1 bind 1 installed 590 sec used 293 sec firstused 295 sec
+	Action statistics:
+	Sent 84 bytes 3 pkt (dropped 3, overlimits 0 requeues 0)
+	backlog 0b 0p requeues 0
+
+	action order 2: bpf drop_reason_control_blocks.o:[p4tc/main] id 94 name tc_ingress_func tag 42e6e971daa41152 jited default-action pipe
+	 index 2 ref 1 bind 1 installed 590 sec used 590 sec
+	Action statistics:
+	Sent 0 bytes 0 pkt (dropped 0, overlimits 0 requeues 0)
+	backlog 0b 0p requeues 0
+```
+
+On <u>terminal 2</u> look for the digest event:
+
+```
+total exts 0
+Added extern 
+        extern order 1:
+          Extern kind Digest
+          Extern instance Ingress_Deparser.digest_inst
+          Extern key 0
+          Params:
+
+          srcAddr  id 2 type macaddr value: 10:00:00:01:aa:bb
+          ingress_port  id 3 type dev value: port0
+          drop_reason  id 4 type bit8  value: 1
+`` 
+
+drop_reason `1` means `PARSER_REJECTED`
+
+Back on terminal 5, generate a TCP packet:
+
+`sudo /home/vagrant/sendpacket/sendpacket.py /home/vagrant/p4tc-examples-pub/drop_reason/testpkt.yml`
+
+Again on <u>terminal 2</u> look for the digest event:
+
+```
+total exts 0
+Added extern 
+        extern order 1:
+          Extern kind Digest
+          Extern instance Ingress_Deparser.digest_inst
+          Extern key 0
+          Params:
+
+          srcAddr  id 2 type macaddr value: 02:03:04:05:06:01
+          ingress_port  id 3 type dev value: port0
+          drop_reason  id 4 type bit8  value: 2
+```
+
+This time the drop_reason is set to `2`, which means `TABLE_MISS`
+
+Ok, back on <u>terminal 4</u> let's create an entry to match on the dst address *10.0.0.2* and rewrite the src mac to *00:01:02:03:04:05* and dst mac *06:07:08:09:11:12* then send out on *port1*
+
+```
+$TC p4ctrl create drop_reason/table/ingress/nh_table \
+dstAddr 10.0.0.2 \
+action send_nh param port port1 param srcMac 06:07:08:09:11:12 param dstMac 00:01:02:03:04:05
+```
+
+If you look at <u>terminal 1</u>, a table create event will be emitted:
+
+```
+created pipeline:  drop_reason(id 1)
+ table: ingress/nh_table(id 1)entry priority 64000[permissions -RUD-PS-R--X--]
+    entry key
+     dstAddr id:1 size:32b type:ipv4 exact fieldval  10.0.0.2/32
+    entry actions:
+        action order 1: drop_reason/ingress/send_nh  index 2 ref 1 bind 1
+         params:
+          port type dev  value: port1 id 1
+
+          srcMac type macaddr  value: 06:07:08:09:11:12 id 2
+
+          dstMac type macaddr  value: 00:01:02:03:04:05 id 3
+
+
+    created by entity: tc (id 2)
+    create by pid: 3921
+    created by process: tc
+    dynamic false
+
+    tmpl created false
+```
+
+On <u>terminal 4</u> watch *port1* traffic (recall that you are watching incoming traffic on <u>terminal 2</u> on *port0*):
+
+`tcpdump -n -i port1 -e`
+
+Now you can send the rewritten mac address when you generate traffic on terminal 5 as follows:
+
+`sudo /home/vagrant/sendpacket/sendpacket.py /home/vagrant/p4tc-examples-pub/drop_reason/testpkt.yml`
+
+Back on <u>terminal 4<\u>:
+
+```
+21:32:09.362397 06:07:08:09:11:12 > 00:01:02:03:04:05, ethertype IPv4 (0x0800), length 54: 10.0.0.1.1235 > 10.0.0.2.4321: Flags [S], seq 0, win 8192, length 0
+```
+
+## General help on runtime CLI
+
+First just dump all possible tables in this program
+
+*$TC p4ctrl create drop_reason/table help*
+
+```
+Tables for pipeline drop_reason:
+	  table name ingress/nh_table
+	  table id 1
+```
+
+As we can see, there is only one with a path ingress/nh_table
+
+Now let's get help on the *create* command for this table:
+
+*$TC p4ctrl create drop_reason/table/ingress/nh_table help*
+
+```
+Key fields for table nh_table:
+	 key name dstAddr
+	 key id 1
+	 key type ipv4
+	 key match type 	 exact
+
+Actions for table nh_table:
+	  act name ingress/send_nh
+	  act id 1
+
+	  Params for ingress/send_nh:
+	    param name port
+	    param id 1
+	    param type dev
+
+	    param name srcMac
+	    param id 2
+	    param type macaddr
+
+	    param name dstMac
+	    param id 3
+	    param type macaddr
+
+          act name ingress/drop
+          act id 2
+```
+
+Above is indicating the table has a key called dstAddr which is of type ipv4 address and that it takes one action:
+  - *send_nh* which takes 3 params 1)*port*, a linux netdev 2) *srcMac*, a mac address 3) *dstMac*, also a mac address
+
+And help on the *delete* command:
+
+*$TC p4ctrl delete drop_reason/table/ingress/nh_table help*
+
+```
+Key fields for table nh_table:
+	 key name dstAddr
+	 key id 1
+	 key type ipv4
+	 key match type  exact
+```
+
+This shows the key name "dstAddr" as an exact IPv4 address.
+Example to delete the entry we created:
+
+*$TC p4ctrl delete drop_reason/table/ingress/nh_table dstAddr 10.0.0.2*
+
+And to delete/flush the whole table:
+
+*$TC p4ctrl delete drop_reason/table/ingress/nh_table
+
+And help on the *get* command:
+
+*$TC p4ctrl get drop_reason/table/ingress/nh_table help*
+
+```
+Key fields for table nh_table:
+	 key name dstAddr
+	 key id 1
+	 key type ipv4
+	 key match type 	 exact
+```
+
+This shows the key name "dstAddr" as an exact IPv4 address.
+For example to retrieve the entry we created using our key of 10.0.0.2:
+
+*$TC p4ctrl get drop_reason/table/ingress/nh_table dstAddr 10.0.0.2*
+
+Note, we can dump the whole table as such:
+
+*$TC p4ctrl get drop_reason/table/ingress/nh_table*
+
+
+To cleanup
+----------
+To clean up you need to run the following script on Terminal 4, where the template was installed and the program was instantiated:
+
+`./drop_reason.purge`

--- a/drop_reason/drop_reason.p4
+++ b/drop_reason/drop_reason.p4
@@ -1,0 +1,86 @@
+/* -*- P4_16 -*- */
+
+#include <core.p4>
+#include <tc/pna.p4>
+#include "drop_reason_metadata.p4"
+#include "drop_reason_parser.p4"
+
+#define L3_TABLE_SIZE 2048
+
+struct mac_learn_digest_t {
+    @tc_type("macaddr") bit<48> srcAddr;
+    @tc_type("dev") PortId_t ingress_port;
+    DROP_REASON drop_reason;
+};
+
+/***************** M A T C H - A C T I O N  *********************/
+
+control ingress(
+    inout my_ingress_headers_t  hdr,
+    inout my_ingress_metadata_t meta,
+    in    pna_main_input_metadata_t  istd,
+    inout pna_main_output_metadata_t ostd
+)
+{
+   action send_nh(@tc_type("dev") PortId_t port, @tc_type("macaddr") bit<48> srcMac, @tc_type("macaddr") bit<48> dstMac) {
+        hdr.ethernet.srcAddr = srcMac;
+        hdr.ethernet.dstAddr = dstMac;
+        send_to_port(port);
+   }
+
+   action drop() {
+        meta.ingress_port = istd.input_port;
+        meta.drop_reason = DROP_REASON.TABLE_MISS;
+        meta.send_digest = true;
+        drop_packet();
+   }
+
+    table nh_table {
+        key = {
+            hdr.ipv4.dstAddr : exact @tc_type("ipv4") @name("dstAddr");
+        }
+        actions = {
+            send_nh;
+            drop;
+        }
+        size = L3_TABLE_SIZE;
+        const default_action = drop;
+    }
+
+    apply {
+        if (!meta.send_digest && hdr.ipv4.isValid()) {
+            nh_table.apply();
+        }
+    }
+}
+
+    /*********************  D E P A R S E R  ************************/
+
+control Ingress_Deparser(
+    packet_out pkt,
+    inout    my_ingress_headers_t hdr,
+    in    my_ingress_metadata_t meta,
+    in    pna_main_output_metadata_t ostd)
+{
+   Digest<mac_learn_digest_t>() digest_inst;
+
+   apply {
+       pkt.emit(hdr.ethernet);
+       pkt.emit(hdr.ipv4);
+       if (meta.send_digest) {
+           mac_learn_digest_t mac_learn_digest;
+           mac_learn_digest.srcAddr = hdr.ethernet.srcAddr;
+           mac_learn_digest.ingress_port = meta.ingress_port;
+           mac_learn_digest.drop_reason = meta.drop_reason;
+           digest_inst.pack(mac_learn_digest);
+       }
+   }
+}
+
+/************ F I N A L   P A C K A G E ******************************/
+
+PNA_NIC(
+    Ingress_Parser(),
+    ingress(),
+    Ingress_Deparser()
+) main;

--- a/drop_reason/drop_reason_metadata.p4
+++ b/drop_reason/drop_reason_metadata.p4
@@ -1,0 +1,14 @@
+/* -*- P4_16 -*- */
+
+    /******  G L O B A L   I N G R E S S   M E T A D A T A  *********/
+
+enum bit<8> DROP_REASON {
+    PARSER_REJECTED = 1,
+    TABLE_MISS = 2
+};
+
+struct my_ingress_metadata_t {
+    @tc_type("dev") PortId_t ingress_port;
+    DROP_REASON drop_reason;
+    bool send_digest;
+}

--- a/drop_reason/drop_reason_parser.p4
+++ b/drop_reason/drop_reason_parser.p4
@@ -1,0 +1,68 @@
+/* -*- P4_16 -*- */
+
+/*
+ * CONST VALUES FOR TYPES
+ */
+const bit<8> IP_PROTO_TCP = 0x06;
+const bit<16> ETHERTYPE_IPV4 = 0x0800;
+
+/*
+ * Standard ethernet header
+ */
+header ethernet_t {
+    @tc_type("macaddr") bit<48> dstAddr;
+    @tc_type("macaddr") bit<48> srcAddr;
+    bit<16> etherType;
+}
+
+header ipv4_t {
+    bit<4>  version;
+    bit<4>  ihl;
+    bit<8>  diffserv;
+    bit<16> totalLen;
+    bit<16> identification;
+    bit<3>  flags;
+    bit<13> fragOffset;
+    bit<8>  ttl;
+    bit<8>  protocol;
+    bit<16> hdrChecksum;
+    @tc_type("ipv4") bit<32> srcAddr;
+    @tc_type("ipv4") bit<32> dstAddr;
+}
+
+struct my_ingress_headers_t {
+    ethernet_t   ethernet;
+    ipv4_t       ipv4;
+}
+
+    /***********************  P A R S E R  **************************/
+parser Ingress_Parser(
+        packet_in pkt,
+        out   my_ingress_headers_t  hdr,
+        inout my_ingress_metadata_t meta,
+        in    pna_main_parser_input_metadata_t istd)
+{
+
+    state start {
+        meta.send_digest = false;
+        transition parse_ethernet;
+    }
+
+    state parse_ethernet {
+        pkt.extract(hdr.ethernet);
+        /* Have to unconditionally transition because the compiler doesn't allow transitions in if-stataments*/
+        transition parse_ipv4;
+    }
+    state parse_ipv4 {
+        if (hdr.ethernet.etherType == ETHERTYPE_IPV4) {
+            pkt.extract(hdr.ipv4);
+        }
+
+        if (!hdr.ipv4.isValid() || hdr.ipv4.protocol != IP_PROTO_TCP) {
+            meta.send_digest = true;
+            meta.ingress_port = istd.input_port;
+            meta.drop_reason = DROP_REASON.PARSER_REJECTED;
+        }
+        transition accept;
+    }
+}

--- a/drop_reason/generated/drop_reason.json
+++ b/drop_reason/generated/drop_reason.json
@@ -1,0 +1,105 @@
+{
+  "schema_version" : "1.0.0",
+  "pipeline_name" : "drop_reason",
+  "externs" : [
+    {
+      "name" : "Digest",
+      "id" : "0x05000000",
+      "permissions" : "0x19b6",
+      "instances" : [
+        {
+          "inst_name" : "Ingress_Deparser.digest_inst",
+          "inst_id" : 1,
+          "params" : [
+            {
+              "id" : 1,
+              "name" : "index",
+              "type" : "bit32",
+              "attr" : "tc_key",
+              "bitwidth" : 32
+            },
+            {
+              "id" : 2,
+              "name" : "srcAddr",
+              "type" : "macaddr",
+              "attr" : "param",
+              "bitwidth" : 48
+            },
+            {
+              "id" : 3,
+              "name" : "ingress_port",
+              "type" : "dev",
+              "attr" : "param",
+              "bitwidth" : 32
+            },
+            {
+              "id" : 4,
+              "name" : "drop_reason",
+              "type" : "bit8",
+              "attr" : "param",
+              "bitwidth" : 8
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "tables" : [
+    {
+      "name" : "ingress/nh_table",
+      "id" : 1,
+      "tentries" : 2048,
+      "permissions" : "0x3da4",
+      "nummask" : 8,
+      "keysize" : 32,
+      "keyfields" : [
+        {
+          "id" : 1,
+          "name" : "dstAddr",
+          "type" : "ipv4",
+          "match_type" : "exact",
+          "bitwidth" : 32
+        }
+      ],
+      "actions" : [
+        {
+          "id" : 1,
+          "name" : "ingress/send_nh",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "params" : [
+            {
+              "id" : 1,
+              "name" : "port",
+              "type" : "dev",
+              "bitwidth" : 32
+            },
+            {
+              "id" : 2,
+              "name" : "srcMac",
+              "type" : "macaddr",
+              "bitwidth" : 48
+            },
+            {
+              "id" : 3,
+              "name" : "dstMac",
+              "type" : "macaddr",
+              "bitwidth" : 48
+            }
+          ],
+          "default_hit_action" : false,
+          "default_miss_action" : false
+        },
+        {
+          "id" : 2,
+          "name" : "ingress/drop",
+          "action_scope" : "TableAndDefault",
+          "annotations" : [],
+          "params" : [],
+          "default_hit_action" : false,
+          "default_miss_action" : true
+        }
+      ]
+    }
+  ]
+}

--- a/drop_reason/generated/drop_reason.purge
+++ b/drop_reason/generated/drop_reason.purge
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+: "${TC:="tc"}"
+
+$TC filter del block 21 ingress protocol all prio 10 p4 pname drop_reason
+sleep 2
+$TC p4template del pipeline/drop_reason
+$TC p4template del extern/root/Digest
+rmmod ext_Digest.ko
+sudo rm -rf /sys/fs/bpf/tc/globals/

--- a/drop_reason/generated/drop_reason.template
+++ b/drop_reason/generated/drop_reason.template
@@ -1,0 +1,30 @@
+#!/bin/bash -x
+
+set -e
+
+: "${TC:="tc"}"
+$TC p4template create pipeline/drop_reason numtables 1
+
+$TC p4template create action/drop_reason/ingress/send_nh actid 1 \
+	param port type dev \
+	param srcMac type macaddr \
+	param dstMac type macaddr
+$TC p4template update action/drop_reason/ingress/send_nh state active
+
+$TC p4template create action/drop_reason/ingress/drop actid 2
+$TC p4template update action/drop_reason/ingress/drop state active
+
+$TC p4template create extern/root/Digest extid 0x05000000 numinstances 1 tc_acl 0x19b6 has_exec_method
+
+$TC p4template create extern_inst/drop_reason/Digest/Ingress_Deparser.digest_inst instid 1 \
+tc_numel 0 \
+control_path tc_key index ptype bit32 id 1 param srcAddr ptype macaddr id 2 param ingress_port ptype dev id 3 param drop_reason ptype bit8 id 4
+
+$TC p4template create table/drop_reason/ingress/nh_table \
+	tblid 1 \
+	type exact \
+	keysz 32 permissions 0x3da4 tentries 2048 nummasks 1 \
+	table_acts act name drop_reason/ingress/send_nh \
+	act name drop_reason/ingress/drop
+$TC p4template update table/drop_reason/ingress/nh_table default_miss_action permissions 0x1024 action drop_reason/ingress/drop
+$TC p4template update pipeline/drop_reason state ready

--- a/drop_reason/generated/drop_reason_control_blocks.c
+++ b/drop_reason/generated/drop_reason_control_blocks.c
@@ -1,0 +1,315 @@
+#include "drop_reason_parser.h"
+struct p4tc_filter_fields p4tc_filter_fields;
+
+struct internal_metadata {
+    __u16 pkt_ether_type;
+} __attribute__((aligned(4)));
+
+struct __attribute__((__packed__)) ingress_nh_table_key {
+    u32 keysz;
+    u32 maskid;
+    u32 field0; /* hdr.ipv4.dstAddr */
+} __attribute__((aligned(8)));
+#define INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH 1
+#define INGRESS_NH_TABLE_ACT_INGRESS_DROP 2
+#define INGRESS_NH_TABLE_ACT_NOACTION 0
+struct __attribute__((__packed__)) ingress_nh_table_value {
+    unsigned int action;
+    u32 hit:1,
+    is_default_miss_act:1,
+    is_default_hit_act:1;
+    union {
+        struct {
+        } _NoAction;
+        struct __attribute__((__packed__)) {
+            u32 port;
+            u64 srcMac;
+            u64 dstMac;
+        } ingress_send_nh;
+        struct {
+        } ingress_drop;
+    } u;
+};
+
+static __always_inline int process(struct __sk_buff *skb, struct my_ingress_headers_t *hdr, struct pna_global_metadata *compiler_meta__)
+{
+    struct hdr_md *hdrMd;
+
+    unsigned ebpf_packetOffsetInBits_save = 0;
+    ParserError_t ebpf_errorCode = NoError;
+    void* pkt = ((void*)(long)skb->data);
+    u8* hdr_start = pkt;
+    void* ebpf_packetEnd = ((void*)(long)skb->data_end);
+    u32 ebpf_zero = 0;
+    u32 ebpf_one = 1;
+    unsigned char ebpf_byte;
+    u32 pkt_len = skb->len;
+
+    struct my_ingress_metadata_t *meta;
+    hdrMd = BPF_MAP_LOOKUP_ELEM(hdr_md_cpumap, &ebpf_zero);
+    if (!hdrMd)
+        return TC_ACT_SHOT;
+    unsigned ebpf_packetOffsetInBits = hdrMd->ebpf_packetOffsetInBits;
+    hdr_start = pkt + BYTES(ebpf_packetOffsetInBits);
+    hdr = &(hdrMd->cpumap_hdr);
+    meta = &(hdrMd->cpumap_usermeta);
+{
+        u8 hit;
+        {
+if (!meta->send_digest && /* hdr->ipv4.isValid() */
+            hdr->ipv4.ebpf_valid) {
+/* nh_table.apply() */
+                {
+                    /* construct key */
+                    struct p4tc_table_entry_act_bpf_params__local params = {
+                        .pipeid = p4tc_filter_fields.pipeid,
+                        .tblid = 1
+                    };
+                    struct ingress_nh_table_key key;
+                    __builtin_memset(&key, 0, sizeof(key));
+                    key.keysz = 32;
+                    key.field0 = hdr->ipv4.dstAddr;
+                    struct p4tc_table_entry_act_bpf *act_bpf;
+                    /* value */
+                    struct ingress_nh_table_value *value = NULL;
+                    /* perform lookup */
+                    act_bpf = bpf_p4tc_tbl_read(skb, &params, sizeof(params), &key, sizeof(key));
+                    value = (struct ingress_nh_table_value *)act_bpf;
+                    if (value == NULL) {
+                        /* miss; find default action */
+                        hit = 0;
+                    } else {
+                        hit = value->hit;
+                    }
+                    if (value != NULL) {
+                        /* run action */
+                        switch (value->action) {
+                            case INGRESS_NH_TABLE_ACT_INGRESS_SEND_NH: 
+                                {
+                                    hdr->ethernet.srcAddr = value->u.ingress_send_nh.srcMac;
+                                                                        hdr->ethernet.dstAddr = value->u.ingress_send_nh.dstMac;
+                                    /* send_to_port(value->u.ingress_send_nh.port) */
+                                    compiler_meta__->drop = false;
+                                    send_to_port(value->u.ingress_send_nh.port);
+                                }
+                                break;
+                            case INGRESS_NH_TABLE_ACT_INGRESS_DROP: 
+                                {
+                                    meta->ingress_port = skb->ifindex;
+                                                                        meta->drop_reason = 2;
+                                                                        meta->send_digest = true;
+                                    /* drop_packet() */
+                                    drop_packet();
+                                }
+                                break;
+                            case INGRESS_NH_TABLE_ACT_NOACTION: 
+                                {
+                                }
+                                break;
+                        }
+                    } else {
+                    }
+                }
+;            }
+
+        }
+    }
+    {
+        struct p4tc_ext_bpf_params ext_params = {};
+        struct mac_learn_digest_t mac_learn_digest;
+        __builtin_memset((void *) &mac_learn_digest, 0, sizeof(struct mac_learn_digest_t ));
+{
+;
+            ;
+            if (meta->send_digest) {
+                mac_learn_digest.srcAddr = hdr->ethernet.srcAddr;
+                                mac_learn_digest.ingress_port = meta->ingress_port;
+                                mac_learn_digest.drop_reason = meta->drop_reason;
+                /* digest_inst.pack(mac_learn_digest) */
+
+                __builtin_memset(&ext_params, 0, sizeof(struct p4tc_ext_bpf_params));
+                ext_params.pipe_id = p4tc_filter_fields.pipeid;
+                ext_params.ext_id = 0x05000000;
+                ext_params.inst_id = 1;
+
+                __builtin_memcpy(ext_params.in_params, &mac_learn_digest, sizeof(struct mac_learn_digest_t ));
+                bpf_p4tc_extern_digest_pack(skb, &ext_params, sizeof(ext_params));
+            }
+        }
+
+        if (compiler_meta__->drop) {
+            return TC_ACT_SHOT;
+        }
+        int outHeaderLength = 0;
+        if (hdr->ethernet.ebpf_valid) {
+            outHeaderLength += 112;
+        }
+;        if (hdr->ipv4.ebpf_valid) {
+            outHeaderLength += 160;
+        }
+;
+        int outHeaderOffset = BYTES(outHeaderLength) - (hdr_start - (u8*)pkt);
+        if (outHeaderOffset != 0) {
+            int returnCode = 0;
+            returnCode = bpf_skb_adjust_room(skb, outHeaderOffset, 1, 0);
+            if (returnCode) {
+                return TC_ACT_SHOT;
+            }
+        }
+        pkt = ((void*)(long)skb->data);
+        ebpf_packetEnd = ((void*)(long)skb->data_end);
+        ebpf_packetOffsetInBits = 0;
+        if (hdr->ethernet.ebpf_valid) {
+            if (ebpf_packetEnd < pkt + BYTES(ebpf_packetOffsetInBits + 112)) {
+                return TC_ACT_SHOT;
+            }
+            
+            ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[1];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 1, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[2];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 2, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[3];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 3, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[4];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 4, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.dstAddr))[5];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
+            ebpf_packetOffsetInBits += 48;
+
+            ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[1];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 1, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[2];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 2, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[3];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 3, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[4];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 4, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.srcAddr))[5];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 5, (ebpf_byte));
+            ebpf_packetOffsetInBits += 48;
+
+            hdr->ethernet.etherType = bpf_htons(hdr->ethernet.etherType);
+            ebpf_byte = ((char*)(&hdr->ethernet.etherType))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ethernet.etherType))[1];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 1, (ebpf_byte));
+            ebpf_packetOffsetInBits += 16;
+
+        }
+;        if (hdr->ipv4.ebpf_valid) {
+            if (ebpf_packetEnd < pkt + BYTES(ebpf_packetOffsetInBits + 160)) {
+                return TC_ACT_SHOT;
+            }
+            
+            ebpf_byte = ((char*)(&hdr->ipv4.version))[0];
+            write_partial(pkt + BYTES(ebpf_packetOffsetInBits) + 0, 4, 4, (ebpf_byte >> 0));
+            ebpf_packetOffsetInBits += 4;
+
+            ebpf_byte = ((char*)(&hdr->ipv4.ihl))[0];
+            write_partial(pkt + BYTES(ebpf_packetOffsetInBits) + 0, 4, 0, (ebpf_byte >> 0));
+            ebpf_packetOffsetInBits += 4;
+
+            ebpf_byte = ((char*)(&hdr->ipv4.diffserv))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_packetOffsetInBits += 8;
+
+            hdr->ipv4.totalLen = bpf_htons(hdr->ipv4.totalLen);
+            ebpf_byte = ((char*)(&hdr->ipv4.totalLen))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.totalLen))[1];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 1, (ebpf_byte));
+            ebpf_packetOffsetInBits += 16;
+
+            hdr->ipv4.identification = bpf_htons(hdr->ipv4.identification);
+            ebpf_byte = ((char*)(&hdr->ipv4.identification))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.identification))[1];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 1, (ebpf_byte));
+            ebpf_packetOffsetInBits += 16;
+
+            ebpf_byte = ((char*)(&hdr->ipv4.flags))[0];
+            write_partial(pkt + BYTES(ebpf_packetOffsetInBits) + 0, 3, 5, (ebpf_byte >> 0));
+            ebpf_packetOffsetInBits += 3;
+
+            hdr->ipv4.fragOffset = bpf_htons(hdr->ipv4.fragOffset << 3);
+            ebpf_byte = ((char*)(&hdr->ipv4.fragOffset))[0];
+            write_partial(pkt + BYTES(ebpf_packetOffsetInBits) + 0, 5, 0, (ebpf_byte >> 3));
+            write_partial(pkt + BYTES(ebpf_packetOffsetInBits) + 0 + 1, 3, 5, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.fragOffset))[1];
+            write_partial(pkt + BYTES(ebpf_packetOffsetInBits) + 1, 5, 0, (ebpf_byte >> 3));
+            ebpf_packetOffsetInBits += 13;
+
+            ebpf_byte = ((char*)(&hdr->ipv4.ttl))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_packetOffsetInBits += 8;
+
+            ebpf_byte = ((char*)(&hdr->ipv4.protocol))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_packetOffsetInBits += 8;
+
+            hdr->ipv4.hdrChecksum = bpf_htons(hdr->ipv4.hdrChecksum);
+            ebpf_byte = ((char*)(&hdr->ipv4.hdrChecksum))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.hdrChecksum))[1];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 1, (ebpf_byte));
+            ebpf_packetOffsetInBits += 16;
+
+            ebpf_byte = ((char*)(&hdr->ipv4.srcAddr))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.srcAddr))[1];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 1, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.srcAddr))[2];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 2, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.srcAddr))[3];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 3, (ebpf_byte));
+            ebpf_packetOffsetInBits += 32;
+
+            ebpf_byte = ((char*)(&hdr->ipv4.dstAddr))[0];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 0, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.dstAddr))[1];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 1, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.dstAddr))[2];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 2, (ebpf_byte));
+            ebpf_byte = ((char*)(&hdr->ipv4.dstAddr))[3];
+            write_byte(pkt, BYTES(ebpf_packetOffsetInBits) + 3, (ebpf_byte));
+            ebpf_packetOffsetInBits += 32;
+
+        }
+;
+    }
+    return -1;
+}
+SEC("p4tc/main")
+int tc_ingress_func(struct __sk_buff *skb) {
+    struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
+    if (compiler_meta__->pass_to_kernel == true) return TC_ACT_OK;
+    compiler_meta__->drop = false;
+    if (!compiler_meta__->recirculated) {
+        compiler_meta__->mark = 153;
+        struct internal_metadata *md = (struct internal_metadata *)(unsigned long)skb->data_meta;
+        if ((void *) ((struct internal_metadata *) md + 1) <= (void *)(long)skb->data) {
+            __u16 *ether_type = (__u16 *) ((void *) (long)skb->data + 12);
+            if ((void *) ((__u16 *) ether_type + 1) > (void *) (long) skb->data_end) {
+                return TC_ACT_SHOT;
+            }
+            *ether_type = md->pkt_ether_type;
+        }
+    }
+    struct hdr_md *hdrMd;
+    struct my_ingress_headers_t *hdr;
+    int ret = -1;
+    ret = process(skb, (struct my_ingress_headers_t *) hdr, compiler_meta__);
+    if (ret != -1) {
+        return ret;
+    }
+    if (!compiler_meta__->drop && compiler_meta__->egress_port == 0) {
+        compiler_meta__->pass_to_kernel = true;
+        return bpf_redirect(skb->ifindex, BPF_F_INGRESS);
+    }
+    return bpf_redirect(compiler_meta__->egress_port, 0);
+}
+char _license[] SEC("license") = "GPL";

--- a/drop_reason/generated/drop_reason_parser.c
+++ b/drop_reason/generated/drop_reason_parser.c
@@ -1,0 +1,161 @@
+#include "drop_reason_parser.h"
+
+struct p4tc_filter_fields p4tc_filter_fields;
+
+static __always_inline int run_parser(struct __sk_buff *skb, struct my_ingress_headers_t *hdr, struct pna_global_metadata *compiler_meta__)
+{
+    struct hdr_md *hdrMd;
+
+    unsigned ebpf_packetOffsetInBits_save = 0;
+    ParserError_t ebpf_errorCode = NoError;
+    void* pkt = ((void*)(long)skb->data);
+    u8* hdr_start = pkt;
+    void* ebpf_packetEnd = ((void*)(long)skb->data_end);
+    u32 ebpf_zero = 0;
+    u32 ebpf_one = 1;
+    unsigned char ebpf_byte;
+    u32 pkt_len = skb->len;
+
+    struct my_ingress_metadata_t *meta;
+
+    hdrMd = BPF_MAP_LOOKUP_ELEM(hdr_md_cpumap, &ebpf_zero);
+    if (!hdrMd)
+        return TC_ACT_SHOT;
+    __builtin_memset(hdrMd, 0, sizeof(struct hdr_md));
+
+    unsigned ebpf_packetOffsetInBits = 0;
+    hdr = &(hdrMd->cpumap_hdr);
+    meta = &(hdrMd->cpumap_usermeta);
+    {
+        goto start;
+        noMatch: {
+/* verify(false, NoMatch) */
+            if (!(false)) {
+                ebpf_errorCode = NoMatch;
+                goto reject;
+            }
+;
+             goto reject;
+        }
+        parse_ipv4_join: {
+            u8 select_0;
+            select_0 = ((!/* hdr->ipv4.isValid() */
+            hdr->ipv4.ebpf_valid || hdr->ipv4.protocol != 0x6) ? 1 : 0);
+            if (select_0 == 1)goto parse_ipv4_true_0;
+            if (select_0 == 0)goto parse_ipv4_join_0;
+            if ((select_0 & 0x0) == (0x0 & 0x0))goto noMatch;
+            else goto reject;
+        }
+        parse_ipv4_join_0: {
+             goto accept;
+        }
+        parse_ipv4_true: {
+/* extract(hdr->ipv4) */
+            if ((u8*)ebpf_packetEnd < hdr_start + BYTES(160 + 0)) {
+                ebpf_errorCode = PacketTooShort;
+                goto reject;
+            }
+
+            hdr->ipv4.version = (u8)((load_byte(pkt, BYTES(ebpf_packetOffsetInBits)) >> 4) & EBPF_MASK(u8, 4));
+            ebpf_packetOffsetInBits += 4;
+
+            hdr->ipv4.ihl = (u8)((load_byte(pkt, BYTES(ebpf_packetOffsetInBits))) & EBPF_MASK(u8, 4));
+            ebpf_packetOffsetInBits += 4;
+
+            hdr->ipv4.diffserv = (u8)((load_byte(pkt, BYTES(ebpf_packetOffsetInBits))));
+            ebpf_packetOffsetInBits += 8;
+
+            hdr->ipv4.totalLen = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));
+            ebpf_packetOffsetInBits += 16;
+
+            hdr->ipv4.identification = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));
+            ebpf_packetOffsetInBits += 16;
+
+            hdr->ipv4.flags = (u8)((load_byte(pkt, BYTES(ebpf_packetOffsetInBits)) >> 5) & EBPF_MASK(u8, 3));
+            ebpf_packetOffsetInBits += 3;
+
+            hdr->ipv4.fragOffset = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))) & EBPF_MASK(u16, 13));
+            ebpf_packetOffsetInBits += 13;
+
+            hdr->ipv4.ttl = (u8)((load_byte(pkt, BYTES(ebpf_packetOffsetInBits))));
+            ebpf_packetOffsetInBits += 8;
+
+            hdr->ipv4.protocol = (u8)((load_byte(pkt, BYTES(ebpf_packetOffsetInBits))));
+            ebpf_packetOffsetInBits += 8;
+
+            hdr->ipv4.hdrChecksum = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));
+            ebpf_packetOffsetInBits += 16;
+
+            __builtin_memcpy(&hdr->ipv4.srcAddr, pkt + BYTES(ebpf_packetOffsetInBits), 4);
+            ebpf_packetOffsetInBits += 32;
+
+            __builtin_memcpy(&hdr->ipv4.dstAddr, pkt + BYTES(ebpf_packetOffsetInBits), 4);
+            ebpf_packetOffsetInBits += 32;
+
+
+            hdr->ipv4.ebpf_valid = 1;
+            hdr_start += BYTES(160);
+
+;
+             goto parse_ipv4_join;
+        }
+        parse_ipv4_true_0: {
+            meta->send_digest = true;            meta->ingress_port = skb->ifindex;            meta->drop_reason = 1;             goto parse_ipv4_join_0;
+        }
+        start: {
+            meta->send_digest = false;/* extract(hdr->ethernet) */
+            if ((u8*)ebpf_packetEnd < hdr_start + BYTES(112 + 0)) {
+                ebpf_errorCode = PacketTooShort;
+                goto reject;
+            }
+
+            __builtin_memcpy(&hdr->ethernet.dstAddr, pkt + BYTES(ebpf_packetOffsetInBits), 6);
+            ebpf_packetOffsetInBits += 48;
+
+            __builtin_memcpy(&hdr->ethernet.srcAddr, pkt + BYTES(ebpf_packetOffsetInBits), 6);
+            ebpf_packetOffsetInBits += 48;
+
+            hdr->ethernet.etherType = (u16)((load_half(pkt, BYTES(ebpf_packetOffsetInBits))));
+            ebpf_packetOffsetInBits += 16;
+
+
+            hdr->ethernet.ebpf_valid = 1;
+            hdr_start += BYTES(112);
+
+;
+            u8 select_1;
+            select_1 = (hdr->ethernet.etherType == 0x800 ? 1 : 0);
+            if (select_1 == 1)goto parse_ipv4_true;
+            if (select_1 == 0)goto parse_ipv4_join;
+            if ((select_1 & 0x0) == (0x0 & 0x0))goto noMatch;
+            else goto reject;
+        }
+
+        reject: {
+            if (ebpf_errorCode == 0) {
+                return TC_ACT_SHOT;
+            }
+            compiler_meta__->parser_error = ebpf_errorCode;
+            goto accept;
+        }
+
+    }
+
+    accept:
+    hdrMd->ebpf_packetOffsetInBits = ebpf_packetOffsetInBits;
+    return -1;
+}
+
+SEC("p4tc/parse")
+int tc_parse_func(struct __sk_buff *skb) {
+    struct pna_global_metadata *compiler_meta__ = (struct pna_global_metadata *) skb->cb;
+    struct hdr_md *hdrMd;
+    struct my_ingress_headers_t *hdr;
+    int ret = -1;
+    ret = run_parser(skb, (struct my_ingress_headers_t *) hdr, compiler_meta__);
+    if (ret != -1) {
+        return ret;
+    }
+    return TC_ACT_PIPE;
+    }
+char _license[] SEC("license") = "GPL";

--- a/drop_reason/generated/drop_reason_parser.h
+++ b/drop_reason/generated/drop_reason_parser.h
@@ -1,0 +1,163 @@
+#include "ebpf_kernel.h"
+
+#include <stdbool.h>
+#include <linux/if_ether.h>
+#include "pna.h"
+
+#define EBPF_MASK(t, w) ((((t)(1)) << (w)) - (t)1)
+#define BYTES(w) ((w) / 8)
+#define write_partial(a, w, s, v) do { *((u8*)a) = ((*((u8*)a)) & ~(EBPF_MASK(u8, w) << s)) | (v << s) ; } while (0)
+#define write_byte(base, offset, v) do { *(u8*)((base) + (offset)) = (v); } while (0)
+#define bpf_trace_message(fmt, ...)
+
+
+struct my_ingress_metadata_t {
+    u32 ingress_port; /* PortId_t */
+    u8 drop_reason; /* bit<8> */
+    u8 send_digest; /* bool */
+};
+struct ethernet_t {
+    u64 dstAddr; /* bit<48> */
+    u64 srcAddr; /* bit<48> */
+    u16 etherType; /* bit<16> */
+    u8 ebpf_valid;
+};
+struct ipv4_t {
+    u8 version; /* bit<4> */
+    u8 ihl; /* bit<4> */
+    u8 diffserv; /* bit<8> */
+    u16 totalLen; /* bit<16> */
+    u16 identification; /* bit<16> */
+    u8 flags; /* bit<3> */
+    u16 fragOffset; /* bit<13> */
+    u8 ttl; /* bit<8> */
+    u8 protocol; /* bit<8> */
+    u16 hdrChecksum; /* bit<16> */
+    u32 srcAddr; /* bit<32> */
+    u32 dstAddr; /* bit<32> */
+    u8 ebpf_valid;
+};
+struct my_ingress_headers_t {
+    struct ethernet_t ethernet; /* ethernet_t */
+    struct ipv4_t ipv4; /* ipv4_t */
+};
+struct mac_learn_digest_t {
+    u64 srcAddr; /* bit<48> */
+    u32 ingress_port; /* PortId_t */
+    u8 drop_reason; /* bit<8> */
+};
+
+struct hdr_md {
+    struct my_ingress_headers_t cpumap_hdr;
+    struct my_ingress_metadata_t cpumap_usermeta;
+    unsigned ebpf_packetOffsetInBits;
+    __u8 __hook;
+};
+
+struct p4tc_filter_fields {
+    __u32 pipeid;
+    __u32 handle;
+    __u32 classid;
+    __u32 chain;
+    __u32 blockid;
+    __be16 proto;
+    __u16 prio;
+};
+
+REGISTER_START()
+REGISTER_TABLE(hdr_md_cpumap, BPF_MAP_TYPE_PERCPU_ARRAY, u32, struct hdr_md, 2)
+BPF_ANNOTATE_KV_PAIR(hdr_md_cpumap, u32, struct hdr_md)
+REGISTER_END()
+
+static __always_inline
+void crc16_update(u16 * reg, const u8 * data, u16 data_size, const u16 poly) {
+    if (data_size <= 8)
+        data += data_size - 1;
+    #pragma clang loop unroll(full)
+    for (u16 i = 0; i < data_size; i++) {
+        bpf_trace_message("CRC16: data byte: %x\n", *data);
+        *reg ^= *data;
+        for (u8 bit = 0; bit < 8; bit++) {
+            *reg = (*reg) & 1 ? ((*reg) >> 1) ^ poly : (*reg) >> 1;
+        }
+        if (data_size <= 8)
+            data--;
+        else
+            data++;
+    }
+}
+static __always_inline u16 crc16_finalize(u16 reg) {
+    return reg;
+}
+static __always_inline
+void crc32_update(u32 * reg, const u8 * data, u16 data_size, const u32 poly) {
+    u32* current = (u32*) data;
+    u32 index = 0;
+    u32 lookup_key = 0;
+    u32 lookup_value = 0;
+    u32 lookup_value1 = 0;
+    u32 lookup_value2 = 0;
+    u32 lookup_value3 = 0;
+    u32 lookup_value4 = 0;
+    u32 lookup_value5 = 0;
+    u32 lookup_value6 = 0;
+    u32 lookup_value7 = 0;
+    u32 lookup_value8 = 0;
+    u16 tmp = 0;
+    if (crc32_table != NULL) {
+        for (u16 i = data_size; i >= 8; i -= 8) {
+            /* Vars one and two will have swapped byte order if data_size == 8 */
+            if (data_size == 8) current = (u32 *)(data + 4);
+            bpf_trace_message("CRC32: data dword: %x\n", *current);
+            u32 one = (data_size == 8 ? __builtin_bswap32(*current--) : *current++) ^ *reg;
+            bpf_trace_message("CRC32: data dword: %x\n", *current);
+            u32 two = (data_size == 8 ? __builtin_bswap32(*current--) : *current++);
+            lookup_key = (one & 0x000000FF);
+            lookup_value8 = crc32_table[(u16)(1792 + (u8)lookup_key)];
+            lookup_key = (one >> 8) & 0x000000FF;
+            lookup_value7 = crc32_table[(u16)(1536 + (u8)lookup_key)];
+            lookup_key = (one >> 16) & 0x000000FF;
+            lookup_value6 = crc32_table[(u16)(1280 + (u8)lookup_key)];
+            lookup_key = one >> 24;
+            lookup_value5 = crc32_table[(u16)(1024 + (u8)(lookup_key))];
+            lookup_key = (two & 0x000000FF);
+            lookup_value4 = crc32_table[(u16)(768 + (u8)lookup_key)];
+            lookup_key = (two >> 8) & 0x000000FF;
+            lookup_value3 = crc32_table[(u16)(512 + (u8)lookup_key)];
+            lookup_key = (two >> 16) & 0x000000FF;
+            lookup_value2 = crc32_table[(u16)(256 + (u8)lookup_key)];
+            lookup_key = two >> 24;
+            lookup_value1 = crc32_table[(u8)(lookup_key)];
+            *reg = lookup_value8 ^ lookup_value7 ^ lookup_value6 ^ lookup_value5 ^
+                   lookup_value4 ^ lookup_value3 ^ lookup_value2 ^ lookup_value1;
+            tmp += 8;
+        }
+        volatile int std_algo_lookup_key = 0;
+        if (data_size < 8) {
+            unsigned char *currentChar = (unsigned char *) current;
+            currentChar += data_size - 1;
+            for (u16 i = tmp; i < data_size; i++) {
+                bpf_trace_message("CRC32: data byte: %x\n", *currentChar);
+                std_algo_lookup_key = (u32)(((*reg) & 0xFF) ^ *currentChar--);
+                if (std_algo_lookup_key >= 0) {
+                    lookup_value = crc32_table[(u8)(std_algo_lookup_key & 255)];
+                }
+                *reg = ((*reg) >> 8) ^ lookup_value;
+            }
+        } else {
+            /* Consume data not processed by slice-by-8 algorithm above, these data are in network byte order */
+            unsigned char *currentChar = (unsigned char *) current;
+            for (u16 i = tmp; i < data_size; i++) {
+                bpf_trace_message("CRC32: data byte: %x\n", *currentChar);
+                std_algo_lookup_key = (u32)(((*reg) & 0xFF) ^ *currentChar++);
+                if (std_algo_lookup_key >= 0) {
+                    lookup_value = crc32_table[(u8)(std_algo_lookup_key & 255)];
+                }
+                *reg = ((*reg) >> 8) ^ lookup_value;
+            }
+        }
+    }
+}
+static __always_inline u32 crc32_finalize(u32 reg) {
+    return reg ^ 0xFFFFFFFF;
+}

--- a/drop_reason/testpkt.yml
+++ b/drop_reason/testpkt.yml
@@ -1,0 +1,11 @@
+packet:
+  send_iface: "p4port0"
+  ether:
+    src: "02:03:04:05:06:01"
+    dst: "00:90:fb:65:d6:fe"
+  ip:
+    src: "10.0.0.1"
+    dst: "10.0.0.2"
+  tcp:
+    sport: 1235
+    dport: 4321


### PR DESCRIPTION
Add drop reason example  that drops a packet, and sends a digest message
containing the ingress port (port where the packet arrived), the src
mac address and the drop reason (PARSER_REJECTED or TABLE_MISS)
If the packet is not dropped, it will be redirected